### PR TITLE
Add npm release action

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,28 @@
+name: Release Published
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm install
+      - run: npm run build
+      # - run: npm run test
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      - name: Resync Maintenance
+        if: ${{ endsWith(github.ref, '.0') }}
+        run: |
+          git checkout maintenance
+          git reset --hard origin/main
+          git push --force origin maintenance


### PR DESCRIPTION
## Description

- Adds the release workflow used on other flowforge projects. Now, when we tag `vx.x.x` it will auto publish to `npm`

## Related Issue(s)

Closes #4

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)

