### PR TITLE
Replace flowforge issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,34 @@
+name: 🐞 Report a bug
+description: File a bug/issue on the FlowForge platform
+labels: [needs-triage]
+body:
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: A clear & concise description of what you're experiencing.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A clear & concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Environment
+    description: Please tell us about your environment. Include any relevant information on how you are running Node-RED.
+    value: |
+        - FlowForge version:
+        - Node.js version:
+        - npm version:
+        - Platform/OS:
+        - Browser:
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,20 @@
+name: 💡 Feature Request
+description: Propose a new feature for the platform
+labels: [needs-triage, feature-request]
+body:
+- type: textarea
+  attributes:
+    label: Description
+    description: Describe the feature
+- type: dropdown
+  id: estimation
+  attributes:
+    label: Have you provided an initial effort estimate for this issue?
+    description: See our [handbook](https://flowforge.com/handbook/development/releases/planning/#effort-estimation) for more details.
+    multiple: false
+    options:
+      - I have provided an initial effort estimate
+      - I am not a FlowForge team member
+      - I can not provide an initial effort estimate
+  validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,12 @@
+name: 📄 Task
+description: Create a task
+labels: [task]
+body:
+- type: markdown
+  attributes:
+    value: |
+      A task is a discrete piece of work that needs doing, that isn't a feature request
+- type: textarea
+  attributes:
+    label: Description
+    description: Describe the task


### PR DESCRIPTION
## Description

This repo was inheriting the default issue templates, instead, we should have a different selection given that this will be a much more community-focussed repository. I have added:

- Feature Request
- Task
- Report Bug

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)